### PR TITLE
update to use register instead of register_vnode_module

### DIFF
--- a/riak_core_app.erl
+++ b/riak_core_app.erl
@@ -12,7 +12,7 @@
 start(_StartType, _StartArgs) ->
     case {{appid}}_sup:start_link() of
         {ok, Pid} ->
-            ok = riak_core:register_vnode_module({{appid}}_vnode),
+            ok = riak_core:register([{vnode_module, {{appid}}_vnode}]),
             ok = riak_core_ring_events:add_guarded_handler({{appid}}_ring_event_handler, []),
             ok = riak_core_node_watcher_events:add_guarded_handler({{appid}}_node_event_handler, []),
             ok = riak_core_node_watcher:service_up({{appid}}, self()),


### PR DESCRIPTION
just a quick update to use the latest stuff in riak_core. i made the changes while i was creating my own riak_core project using the templates.
